### PR TITLE
gnu submodule update

### DIFF
--- a/gnu/gmake/checksums
+++ b/gnu/gmake/checksums
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/core/make/checksums
+../../kiss-repo/core/binutils/checksums

--- a/gnu/gmake/checksums
+++ b/gnu/gmake/checksums
@@ -1,1 +1,1 @@
-../../kiss-repo/core/binutils/checksums
+../../kiss-repo/core/make/checksums

--- a/gnu/gmake/sources
+++ b/gnu/gmake/sources
@@ -1,1 +1,1 @@
-../../kiss-repo/core/binutils/sources
+../../kiss-repo/core/make/sources

--- a/gnu/gmake/sources
+++ b/gnu/gmake/sources
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/core/make/sources
+../../kiss-repo/core/binutils/sources

--- a/gnu/gmake/version
+++ b/gnu/gmake/version
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/core/make/version
+../../kiss-repo/core/binutils/version

--- a/gnu/gmake/version
+++ b/gnu/gmake/version
@@ -1,1 +1,1 @@
-../../kiss-repo/core/binutils/version
+../../kiss-repo/core/make/version

--- a/gnu/gnu-as/checksums
+++ b/gnu/gnu-as/checksums
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/core/binutils/checksums
+../../kiss-repo/core/binutils/checksums

--- a/gnu/gnu-as/sources
+++ b/gnu/gnu-as/sources
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/core/binutils/sources
+../../kiss-repo/core/binutils/sources

--- a/gnu/gnu-as/version
+++ b/gnu/gnu-as/version
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/core/binutils/version
+../../kiss-repo/core/binutils/version

--- a/gnu/gperf/checksums
+++ b/gnu/gperf/checksums
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/extra/gperf/checksums
+../../kiss-repo/core/binutils/checksums

--- a/gnu/gperf/checksums
+++ b/gnu/gperf/checksums
@@ -1,1 +1,1 @@
-../../kiss-repo/core/binutils/checksums
+../../kiss-repo/extra/gperf/checksums

--- a/gnu/gperf/sources
+++ b/gnu/gperf/sources
@@ -1,1 +1,1 @@
-../../kiss-repo/core/binutils/sources
+../../kiss-repo/extra/gperf/sources

--- a/gnu/gperf/sources
+++ b/gnu/gperf/sources
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/extra/gperf/sources
+../../kiss-repo/core/binutils/sources

--- a/gnu/gperf/version
+++ b/gnu/gperf/version
@@ -1,1 +1,1 @@
-../../kiss-repo/core/binutils/version
+../../kiss-repo/extra/gperf/version

--- a/gnu/gperf/version
+++ b/gnu/gperf/version
@@ -1,1 +1,1 @@
-/var/db/kiss/repo/extra/gperf/version
+../../kiss-repo/core/binutils/version


### PR DESCRIPTION
transitioned these to relative links to the kiss-repo submodule, `kiss update` stops when it finds the missing links now that I have moved packages out of `/var/db/repo`